### PR TITLE
Add package.json for MIP compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,10 @@
+{
+  "urls": [
+    ["LightLora/__init__.py", "github:MZachmann/LightLora_MicroPython/LightLora/__init__.py"],
+    ["LightLora/lorautil.py", "github:MZachmann/LightLora_MicroPython/LightLora/lorautil.py"],
+    ["LightLora/spicontrol.py", "github:MZachmann/LightLora_MicroPython/LightLora/spicontrol.py"],
+    ["LightLora/sx127x.py", "github:MZachmann/LightLora_MicroPython/LightLora/sx127x.py"]
+  ],
+  "version": "1.0.0",
+  "deps": []
+}


### PR DESCRIPTION
## Summary
- Add package.json file to make this library installable via the MicroPython Package Manager (MIP)
- Enables installation with `mip install github:MZachmann/LightLora_MicroPython`
- Includes all necessary module files

## Test plan
- Verify that the package can be installed using MIP

🤖 Generated with [Claude Code](https://claude.ai/code)